### PR TITLE
Add TextTemplateNode for {placeholder} prompt template substitution

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,15 +1,18 @@
 try:
     from .random_line_from_text_node import RandomLineFromTextNode
     from .load_description_node import LoadDescriptionNode
+    from .text_template_node import TextTemplateNode
 
     NODE_CLASS_MAPPINGS = {
         "RandomLineFromText": RandomLineFromTextNode,
         "LoadDescriptionNode": LoadDescriptionNode,
+        "TextTemplate": TextTemplateNode,
     }
 
     NODE_DISPLAY_NAME_MAPPINGS = {
         "RandomLineFromText": "Random Line From Text",
         "LoadDescriptionNode": "Load Description",
+        "TextTemplate": "Text Template",
     }
 
     __all__ = [

--- a/tests/test_text_template_node.py
+++ b/tests/test_text_template_node.py
@@ -1,0 +1,81 @@
+import pytest
+
+import text_template_node as ttn
+from text_template_node import TextTemplateNode
+
+
+class TestFillTemplate:
+    def test_single_substitution(self):
+        node = TextTemplateNode()
+        result, = node.fill_template("{name}", key_1="name", value_1="Alice")
+        assert result == "Alice"
+
+    def test_multiple_substitutions(self):
+        node = TextTemplateNode()
+        result, = node.fill_template(
+            "{adj} {noun}",
+            key_1="adj", value_1="brave",
+            key_2="noun", value_2="warrior",
+        )
+        assert result == "brave warrior"
+
+    def test_unknown_placeholder_preserved(self):
+        node = TextTemplateNode()
+        result, = node.fill_template("{unknown}")
+        assert result == "{unknown}"
+
+    def test_empty_key_is_skipped(self):
+        node = TextTemplateNode()
+        result, = node.fill_template("{x}", key_1="", value_1="something")
+        assert result == "{x}"
+
+    def test_whitespace_key_is_stripped(self):
+        node = TextTemplateNode()
+        result, = node.fill_template("{name}", key_1="  name  ", value_1="Bob")
+        assert result == "Bob"
+
+    def test_multiline_value_inserted_verbatim(self):
+        node = TextTemplateNode()
+        multiline = "line one\nline two\nline three"
+        result, = node.fill_template("{desc}", key_1="desc", value_1=multiline)
+        assert result == multiline
+
+    def test_literal_braces_not_treated_as_placeholder(self):
+        node = TextTemplateNode()
+        result, = node.fill_template("{{not a placeholder}}")
+        assert result == "{not a placeholder}"
+
+    def test_malformed_template_returns_original(self):
+        node = TextTemplateNode()
+        malformed = "unclosed { brace"
+        result, = node.fill_template(malformed)
+        assert result == malformed
+
+    def test_all_five_pairs_substituted(self):
+        node = TextTemplateNode()
+        template = "{a} {b} {c} {d} {e}"
+        result, = node.fill_template(
+            template,
+            key_1="a", value_1="1",
+            key_2="b", value_2="2",
+            key_3="c", value_3="3",
+            key_4="d", value_4="4",
+            key_5="e", value_5="5",
+        )
+        assert result == "1 2 3 4 5"
+
+    def test_returns_tuple(self):
+        node = TextTemplateNode()
+        result = node.fill_template("hello")
+        assert isinstance(result, tuple)
+        assert len(result) == 1
+
+    def test_no_keys_leaves_template_unchanged(self):
+        node = TextTemplateNode()
+        result, = node.fill_template("{foo} {bar}")
+        assert result == "{foo} {bar}"
+
+    def test_partial_substitution_leaves_unknown_intact(self):
+        node = TextTemplateNode()
+        result, = node.fill_template("{known} {unknown}", key_1="known", value_1="X")
+        assert result == "X {unknown}"

--- a/text_template_node.py
+++ b/text_template_node.py
@@ -1,0 +1,54 @@
+"""ComfyUI custom node for filling {placeholder} templates from wired string inputs."""
+import logging
+from collections import defaultdict
+
+try:
+    from .config import MAX_FILE_INPUTS
+except ImportError:
+    from config import MAX_FILE_INPUTS
+
+logger = logging.getLogger(__name__)
+
+
+class TextTemplateNode:
+    @classmethod
+    def INPUT_TYPES(cls):
+        optional = {}
+        for i in range(1, MAX_FILE_INPUTS + 1):
+            optional[f"key_{i}"]   = ("STRING", {"default": ""})
+            optional[f"value_{i}"] = ("STRING", {"default": "", "multiline": True})
+        return {
+            "required": {
+                "template": ("STRING", {"default": "{subject} in {setting}", "multiline": True}),
+            },
+            "optional": optional,
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("filled_template",)
+    FUNCTION = "fill_template"
+    CATEGORY = "Feroc"
+
+    def fill_template(self, template: str, **kwargs) -> tuple[str]:
+        """Fill {placeholder} tokens in template with the provided key/value pairs.
+
+        Unknown placeholders are left intact. Malformed templates (e.g. unclosed braces)
+        return the original template unchanged.
+        """
+        substitutions = {}
+        for i in range(1, MAX_FILE_INPUTS + 1):
+            key = kwargs.get(f"key_{i}", "")
+            if key and key.strip():
+                substitutions[key.strip()] = kwargs.get(f"value_{i}", "")
+
+        class _PassthroughDict(defaultdict):
+            def __missing__(self, key):
+                return "{" + key + "}"
+
+        try:
+            result = template.format_map(_PassthroughDict(None, substitutions))
+        except (ValueError, KeyError) as e:
+            logger.warning("Template substitution error: %s", e)
+            result = template
+
+        return (result,)


### PR DESCRIPTION
## Summary

- New node `TextTemplateNode` (`Text Template` in ComfyUI UI)
- Accepts a `template` STRING with `{placeholder}` tokens and up to 5 wired key/value pairs
- Unknown placeholders left intact; malformed templates return unchanged
- 12 tests, all passing

## Test plan

- [x] `python -m pytest tests/ -v` — 53 tests, all pass
- [x] Closes #21